### PR TITLE
Get resolution from display UWP

### DIFF
--- a/Source/Core/DolphinUWP/App.cpp
+++ b/Source/Core/DolphinUWP/App.cpp
@@ -8,7 +8,7 @@
 #include <winrt/Windows.UI.Composition.h>
 #include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.UI.Input.h>
-#include<winrt/windows.graphics.display.core.h>
+#include <winrt/windows.graphics.display.core.h>
 
 #include <Gamingdeviceinformation.h>
 


### PR DESCRIPTION
This allows the output res to match the display res rather than switching between fixed resolutions depending on console.