### PR TITLE
Automate Build Process Further

### DIFF
--- a/Source/Core/DolphinUWP/DolphinUWP.vcxproj
+++ b/Source/Core/DolphinUWP/DolphinUWP.vcxproj
@@ -295,6 +295,13 @@
       <ForceSymbolReferences Condition="'$(Configuration)|$(Platform)'=='Release UWP|Win32'">
       </ForceSymbolReferences>
     </Link>
+    <PreBuildEvent>
+      <Command>
+				mkdir Sys
+				robocopy "..\..\..\Data\Sys\." "Sys\." /xf *.vsh /E /R:0 /W:0
+				EXIT 0
+			</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="D3DWindow.h" />


### PR DESCRIPTION
Previously we needed to manually copy the `Data/Sys` folder to the `Source/Core/DolphinUWP` folder to make a build, so this PR just automates the process so the folder is copied automatically during build time.

Less work for those who wish to make a build themselves :)